### PR TITLE
Fixed indentation in elements/form.sass

### DIFF
--- a/sass/elements/form.sass
+++ b/sass/elements/form.sass
@@ -345,7 +345,7 @@ $input-radius:              $radius !default
       left: 0
   &.has-icons-right
     .input
-        padding-right: 2.25em
+      padding-right: 2.25em
     .icon.is-right
       right: 0
   &.is-loading


### PR DESCRIPTION
### Proposed solution
Resolves an issue where compiling Sass resulted in `error (Line 348 of bower_components/bulma/sass/elements/form.sass: The line was indented 2 levels deeper than the previous line.)`.

### Tradeoffs
None.

### Testing Done
Re-compiled Sass and didn't receive an error message.